### PR TITLE
[fix #22] Modify default C++ template to instantiate classes on heap

### DIFF
--- a/src/main/resources/Resource/GCCTest.cpp
+++ b/src/main/resources/Resource/GCCTest.cpp
@@ -36,11 +36,12 @@ bool do_test(${Method.Params}, ${Method.ReturnType} __expected, int caseNo) {
 ${<if RecordRuntime}
     time_t startClock = clock();
 ${<end}
-    ${ClassName} instance;
-    ${Method.ReturnType} __result = instance.${Method.Name}(${foreach Method.Params par , }${par.Name}${end});
+    ${ClassName} *instance = new ${ClassName}();
+    ${Method.ReturnType} __result = instance->${Method.Name}(${foreach Method.Params par , }${par.Name}${end});
 ${<if RecordRuntime}
     double elapsed = (double)(clock() - startClock) / CLOCKS_PER_SEC;
 ${<end}
+    delete instance;
 
 ${<if Method.ReturnType.RealNumber}
 ${<if Method.ReturnType.Array}


### PR DESCRIPTION
To prevent stackoverflow error when creating an object,
each problem instance should be created on heap rather on stack.
The default C++ test code template is modified to fix this.

Issue: #22
