### PR TITLE
Modify default C++ template to instantiate classes on heap

### DIFF
--- a/src/main/resources/Resource/GCCTest.cpp
+++ b/src/main/resources/Resource/GCCTest.cpp
@@ -36,11 +36,12 @@ bool do_test(${Method.Params}, ${Method.ReturnType} __expected, int caseNo) {
 ${<if RecordRuntime}
     time_t startClock = clock();
 ${<end}
-    ${ClassName} instance;
-    ${Method.ReturnType} __result = instance.${Method.Name}(${foreach Method.Params par , }${par.Name}${end});
+    ${ClassName} *instance = new ${ClassName}();
+    ${Method.ReturnType} __result = instance->${Method.Name}(${foreach Method.Params par , }${par.Name}${end});
 ${<if RecordRuntime}
     double elapsed = (double)(clock() - startClock) / CLOCKS_PER_SEC;
 ${<end}
+    delete instance;
 
 ${<if Method.ReturnType.RealNumber}
 ${<if Method.ReturnType.Array}


### PR DESCRIPTION
In C++ language, if we declare a large-sized array in the class to implement, the struct size of the class grows up. Hence we might get a stack overflow error if problem instances are instantiated on stack, rather on heap.

``` c++
struct TheProblemDiv1 {
   int a[1000][1000];
};

void do_test() {
   TheProblemDiv1 instance; // Stack Overflow!
}
```

Topcoder's current behavior is, each class object is instantiated on heap, so we would expect the above code runs well (unless memory total used is exceeded).

Please modify the default C++ test code template, to instantiate the problem class on heap.
