### PR TITLE
Improvement on the default python test template

### DIFF
--- a/src/main/resources/Resource/Test.py
+++ b/src/main/resources/Resource/Test.py
@@ -1,4 +1,4 @@
-# TEST CODE FOR PYTHON
+# TEST CODE FOR PYTHON {{{
 import sys
 import time
 
@@ -37,7 +37,7 @@ ${<end}
 
     if exception is not None:
         sys.stdout.write("RUNTIME ERROR: \\n")
-        sys.stdout.write(exception + "\n")
+        sys.stdout.write(exception + "\\n")
         return 0
 
     if tc_equal(__result, __expected):
@@ -57,7 +57,7 @@ ${<if !in.Param.Type.Array}
         ${in.Param.Name} = ${in}
 ${<else}
         ${in.Param.Name} = (${foreach in.ValueList v ,}
-            ${v}${end},
+            ${v}${end}
         )
 ${<end}
 ${<end}
@@ -65,7 +65,7 @@ ${<if !e.Output.Param.Type.Array}
         __expected = ${e.Output}
 ${<else}
         __expected = (${foreach e.Output.ValueList v ,}
-            ${v}${end},
+            ${v}${end}
         )
 ${<end}
 
@@ -103,4 +103,5 @@ ${<end}
 if __name__ == '__main__':
     run_tests()
 
+# }}}
 

--- a/src/test/java/greed/template/PythonTemplateTest.java
+++ b/src/test/java/greed/template/PythonTemplateTest.java
@@ -101,12 +101,12 @@ public class PythonTemplateTest {
         assertThat(testCode, containsString("arg1 = 15"));
         assertThat(testCode, containsString("arg2 = (\n" +
             "            919, 111, 234,\n" +
-            "            234, 567, 555,\n" +
+            "            234, 567, 555\n" +
             "        )"
         ));
         assertThat(testCode, containsString("__expected = (\n" +
             "            \"abcd\", \"efg\",\n" +
-            "            \"123\", \"456\",\n" +
+            "            \"123\", \"456\"\n" +
             "        )"
         ));
         assertThat(testCode, containsString("return do_test(arg1, arg2, arg3, __expected,"));


### PR DESCRIPTION
Hello, again!

The previous pull request #28 added an initial working of python support feature,
and this one addes some improvements on the default test code.

Changes summarized:
- Improve equal operator (to handle tuple/list types, as well as real-valued numbers)
- Fix a compilation error when the parameters or the expected value is an empty tuple
- Typo fix, and a vim-friendly marker is added :)

Please review on this, and after merged I will work on some kind of refactoring
to eliminate duplicated codes, making this feature being closed.
