### PR TITLE
Fix a minor bug on python test code template

### DIFF
--- a/src/main/resources/Resource/Test.py
+++ b/src/main/resources/Resource/Test.py
@@ -40,7 +40,7 @@ ${<end}
         sys.stdout.write(exception + "\\n")
         return 0
 
-    if tc_equal(__result, __expected):
+    if tc_equal(__expected, __result):
         sys.stdout.write("PASSED! " ${if RecordRuntime}+ ("(%.3f seconds)" % elapsed)${end} + "\\n")
         return 1
     else:


### PR DESCRIPTION
This commit fixes a minor typo on python test code, which was introduced in ca1d2c491.
