### PR TITLE
Some contests, like TCO 06 qualification rounds have / in the name

### DIFF
--- a/src/main/java/greed/model/Convert.java
+++ b/src/main/java/greed/model/Convert.java
@@ -12,14 +12,21 @@ public class Convert {
     public static Contest convertContest(com.topcoder.client.contestant.ProblemComponentModel problem) {
         String fullName = problem.getProblem().getRound().getContestName();
         boolean hasDivision = fullName.contains("DIV");
-        if (!hasDivision)
-            return new Contest(fullName, null);
-        else {
+        Integer div = null;
+        String contestName;
+        if (! hasDivision) {
+            contestName = fullName;
+        } else {
             int sp = fullName.indexOf("DIV");
-            String contestName = fullName.substring(0, sp - 1);
+            contestName = fullName.substring(0, sp - 1);
             String divNum = fullName.substring(sp + 4);
-            return new Contest(contestName, Integer.parseInt(divNum));
+            div = Integer.parseInt(divNum);
         }
+        if (contestName.contains("/") ) {
+            contestName = contestName.replace("/", "-");
+        }
+        
+        return new Contest(contestName, div);
     }
 
     public static Language convertLanguage(com.topcoder.shared.language.Language lang) {


### PR DESCRIPTION
It causes issues when opening them in Greed, the name of the contest is TCO 06 Qual 5/6/06, it creates extra folders 6 and /06. I think it makes more sense to replace the / with -. This is minor as this only affects 6 practice rooms.
