### PR TITLE
Use new String() to allocate string arguments before testing. 

### DIFF
--- a/src/main/resources/Resource/Test.java
+++ b/src/main/resources/Resource/Test.java
@@ -32,6 +32,17 @@ ${<end}
 	}
 
 	static void doTest(${Method.Params}, ${Method.ReturnType} __expected, int caseNo) {
+${<foreach Method.Params p}
+${<if p.Type.String}
+${<if p.Type.Array}
+		for (int i = 0; i < ${p.Name}.length; i++) {
+			${p.Name}[i] = new String(${p.Name}[i]);
+		}
+${<else}
+        ${p.Name} = new String(${p.Name});
+${<end}
+${<end}
+${<end}
 ${<if RecordRuntime}
 		long startTime = System.currentTimeMillis();
 ${<end}


### PR DESCRIPTION
Makes Java template allocate String arguments with the new operator. A common bug with new programmers / programmers who coded in a rush is to do == comparisons in simple problems. Like this thread: http://apps.topcoder.com/forums/?module=Thread&threadID=709720&start=0&mc=12#1380722
