### PR TITLE
Let default python template do common imports like the other languages.

### DIFF
--- a/src/main/resources/Resource/Template.py
+++ b/src/main/resources/Resource/Template.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import math,string,itertools,fractions,heapq,collections,re,array,bisect
 
 class ${ClassName}:
     def ${Method.Name}(self, ${Method.Params}):


### PR DESCRIPTION
Python users need libraries too. It is common to use math and itertools. The others can be included too as it is just one line.
