### PR TITLE
pretty_str function to print results in python tester

### DIFF
--- a/src/main/resources/Resource/Test.py
+++ b/src/main/resources/Resource/Test.py
@@ -18,6 +18,14 @@ def tc_equal(expected, received):
     except:
         return False
 
+def pretty_str(x):
+    if type(x) == str:
+        return '"%s"' % x
+    elif type(x) == tuple:
+        return '(%s)' % (','.join( (pretty_str(y) for y in x) ) )
+    else:
+        return str(x)
+        
 def do_test(${Method.Params}, __expected, caseNo):
     sys.stdout.write("  Testcase #%d ... " % caseNo)
 
@@ -45,8 +53,8 @@ ${<end}
         return 1
     else:
         sys.stdout.write("FAILED! " ${if RecordRuntime}+ ("(%.3f seconds)" % elapsed)${end} + "\\n")
-        sys.stdout.write("           Expected: " + str(__expected) + "\\n")
-        sys.stdout.write("           Received: " + str(__result) + "\\n")
+        sys.stdout.write("           Expected: " + pretty_str(__expected) + "\\n")
+        sys.stdout.write("           Received: " + pretty_str(__result) + "\\n")
         return 0
 
 def run_testcase(__no):


### PR DESCRIPTION
This is all just so that when printing strings they get surrounded by "", mostly so that if the method returns an empty string it doesn't look the same as if there was no result. Or if you return 123 instead of "123", whilst python is dynamically typed, TC results aren't.
