### PR TITLE
Allow valueList to iterate through the elements of an array input

### DIFF
--- a/src/main/java/greed/code/lang/CStyleLanguage.java
+++ b/src/main/java/greed/code/lang/CStyleLanguage.java
@@ -48,14 +48,11 @@ public abstract class CStyleLanguage implements LanguageTrait, LanguageRenderer 
             return new ParamValue(param, valueList.toArray(new String[0]));
         } else {
             String[] valueList = value.split(",");
-            StringBuilder buf = new StringBuilder();
             Param paramWithPrim = new Param(param.getName(), new Type(param.getType().getPrimitive(), 0));
             for (int i = 0; i < valueList.length; i++) {
-                if (i > 0) buf.append(", ");
                 valueList[i] = renderParamValue(new ParamValue(paramWithPrim, valueList[i].trim())); 
-                buf.append(valueList[i]);
             }
-            return new ParamValue(param, buf.toString(), valueList);
+            return new ParamValue(param, valueList);
         }
     }
 }

--- a/src/main/java/greed/model/ParamValue.java
+++ b/src/main/java/greed/model/ParamValue.java
@@ -27,12 +27,6 @@ public class ParamValue {
         this.valueList = valueList;
     }
     
-    public ParamValue(Param param, String value, String[] valueList) {
-        this.param = param;
-        this.value = value;
-        this.valueList = valueList;
-    }
-
     public Param getParam() {
         return param;
     }


### PR DESCRIPTION
I tried to use ValueList in a template, only to learn that when the vector is not a string, the ValueList stores a single element in the array containing comma-separated values. This is not a problem at all in the default templates, because they add , anyway, and thus even with the bug the result is the same. But when you need to do something different than separating values with commas, it won't work.

So I added behavior that makes sure to split the values. Also made Value return the comma-separated string directly when that's what you want. And added a new constructor for  to make it all work.
