### PR TITLE
Add .ValueListLength field to ParamValue.

### DIFF
--- a/src/main/java/greed/model/ParamValue.java
+++ b/src/main/java/greed/model/ParamValue.java
@@ -40,7 +40,7 @@ public class ParamValue {
     }
     
     public int getValueListLength() {
-        return valueList.length();
+        return valueList.length;
     }
 
     public boolean isMultiLine() {


### PR DESCRIPTION
I was trying the tmpl-seq branch and was about to have success creating an input file template. But to include array test arguments in ACM style I think it is useful to have a way to fetch the length of the array from the template. Tested merging this on a tmpl-seq branch clone.
