### PR TITLE
Add .ValueListLength field to ParamValue.

### DIFF
--- a/src/main/java/greed/model/ParamValue.java
+++ b/src/main/java/greed/model/ParamValue.java
@@ -38,6 +38,10 @@ public class ParamValue {
     public String[] getValueList() {
         return valueList;
     }
+    
+    public int getValueListLength() {
+        return valueList.length;
+    }
 
     public boolean isMultiLine() {
         return valueList.length > 1;


### PR DESCRIPTION
I was trying the tmpl-seq branch and was about to have success creating an input file template. But to include array test arguments in ACM style I think it is useful to have a way to fetch the length of the array from the template. Tested merging this on a tmpl-seq branch clone.
