### PR TITLE
Fix bug that made greed consider empty non-string lists as having one item

### DIFF
--- a/src/main/java/greed/code/lang/AbstractLanguage.java
+++ b/src/main/java/greed/code/lang/AbstractLanguage.java
@@ -31,6 +31,7 @@ public abstract class AbstractLanguage implements LanguageTrait, LanguageRendere
         value = value.trim();
         value = value.substring(1, value.length() - 1);
         value = value.replaceAll("\n", "");
+        value = value.trim(); //need a second trim in case it is an empty list {  }
         if (param.getType().getPrimitive() == Primitive.STRING) {
             boolean inString = false;
             ArrayList<String> valueList = new ArrayList<String>();
@@ -51,6 +52,9 @@ public abstract class AbstractLanguage implements LanguageTrait, LanguageRendere
             }
 
             return new ParamValue(param, valueList.toArray(new String[0]));
+        } else if (value.length() == 0) {
+            //Empty array
+            return new ParamValue( param, new String[]{} ); 
         } else {
             String[] valueList = value.split(",");
             Param paramWithPrim = new Param(param.getName(), new Type(param.getType().getPrimitive(), 0), param.getIndex());


### PR DESCRIPTION
In SRM 596 div1 500, there was an issue with the test cases. It is an unusual problem that has long[] arguments and return and the arrays are allowed to be empty. Greed was rendering an empty long array as {LL}. It turns out that greed parsed non-string empty arrays wrong, thinking that they have a single element equal to an empty string. This should fix that issue.
