### PR TITLE
Add a defaultLanguage entry for things that are common with all languages

### DIFF
--- a/src/main/resources/default.conf
+++ b/src/main/resources/default.conf
@@ -37,12 +37,15 @@ greed {
                 templateFile = "builtin Problem/desc.html.tmpl"
             }
         }
-
-        cstyleLanguage {
-            cutBegin = "// CUT begin"
-            cutEnd = "// CUT end"
+        
+        defaultLanguage {
             templates = [ test, source, testcase, problemDesc ]
             submitTemplate = source
+        }
+
+        cstyleLanguage = ${greed.shared.defaultLanguage} {
+            cutBegin = "// CUT begin"
+            cutEnd = "// CUT end"
         }
     }
 
@@ -75,7 +78,7 @@ greed {
             }
         }
 
-        python {
+        python = ${greed.shared.defaultLanguage}  {
             cutBegin = "# CUT begin"
             cutEnd = "# CUT end"
 
@@ -85,8 +88,6 @@ greed {
                 source.outputFileExtension = py
             }
 
-            templates = [ test, source, testcase, problemDesc ]
-            submitTemplate = source
         }
     }
 }


### PR DESCRIPTION
I wanted to make an After Gen call to open all source files in an editor automatically. But because python is split from the other languages it was a bit repetitive. This also reduces the default.conf size a bit.
