### PR TITLE
Add GeneratedFileName and GeneratedFilePath fileds for commands.

### DIFF
--- a/src/main/java/greed/Greed.java
+++ b/src/main/java/greed/Greed.java
@@ -198,6 +198,8 @@ public class Greed {
                     CommandConfig afterGen = template.getAfterFileGen();
                     String[] commands = new String[afterGen.getArguments().length + 1];
                     commands[0] = afterGen.getExecute();
+                    currentTemplateModel.put("GeneratedFileName", new java.io.File(filePath).getName());
+                    currentTemplateModel.put("GeneratedFilePath", FileSystem.getRawFile(filePath));
                     for (int i = 1; i < commands.length; ++i) {
                         commands[i] = TemplateEngine.render(afterGen.getArguments()[i - 1], currentTemplateModel);
                     }


### PR DESCRIPTION
This allows you to use ${GeneratedFilePath} in the command line arguments to get the name of the generated file. So that you don't have to retype file name and extension. Useful for hooks that apply to all language sources. Also ${GeneratedFileName} if all you need is the file name.
