### PR TITLE
Makes getRawFile return a canonical path if possible.

### DIFF
--- a/src/main/java/greed/util/FileSystem.java
+++ b/src/main/java/greed/util/FileSystem.java
@@ -54,17 +54,15 @@ public class FileSystem {
         File f = new File(relativePath);
         return f.getParent();
     }
-
     public static File getRawFile(String relativePath) {
-        File f = new File(Configuration.getWorkspace() + "/" + relativePath); 
+        File f = new File(Configuration.getWorkspace() + "/" + relativePath);
         try {
-            File f2 = f.getCanonicalFile();
-            f = f2;
+            return f.getCanonicalFile();
         } catch (IOException e) {
             // leave f untouched, possibly the file path does not exist, so
             // fixing the non-canonical path is not important
+            return f;
         }
-        return f;
     }
 
     public static long getSize(String resourcePath) {


### PR DESCRIPTION
When combining templates and options and the simple concatenation of the getRawFile() method, it tends to generate file paths like "/home/user/something/./SRM 596/" , these paths work fine but we can remove the extra "." and ".." in the path by using getCanonicalFile, too bad that requires some Exception handling.
