### PR TITLE
Fix annotation bug(Greed added empty annotations to problem statement HTML)

### DIFF
--- a/src/main/java/greed/model/Convert.java
+++ b/src/main/java/greed/model/Convert.java
@@ -59,7 +59,7 @@ public class Convert {
             if (i < j) {
                 xml = xml.substring(i + 1, j);
             }
-            xml.trim();
+            xml = xml.trim();
         }
         return xml;
     }


### PR DESCRIPTION
The problem statement template is great, but it was adding annotation sections even when there is no annotation. I researched the bug and it seems that TopCoder's toXML surrounds the contents with <annotation something=1>...</annotation>. This is not HTML and also makes all annotations seem not empty. I had to implement some ad hoc parsing to fix it.
