### PR TITLE
Add a .Modulo field to ProblemDescription.

### DIFF
--- a/src/main/java/greed/model/ProblemDescription.java
+++ b/src/main/java/greed/model/ProblemDescription.java
@@ -10,9 +10,9 @@ public class ProblemDescription {
     private String intro;
     private String[] notes;
     private String[] constraints;
-    private String mod;
+    private String modulo;
     
-    private String extractMod(String intro)
+    private String extractModulo(String intro)
     {
         /* d, modulo 1,000,000,007.</ */
         String pattern = "mod(ulo)? (\\d[\\d,\\.]*\\d)";
@@ -36,7 +36,7 @@ public class ProblemDescription {
         this.intro = intro;
         this.notes = notes;
         this.constraints = constraints;
-        mod = extractMod(intro);
+        this.modulo = extractModulo(intro);
     }
     
     public String getIntro() {
@@ -51,8 +51,8 @@ public class ProblemDescription {
         return constraints;
     }
     
-    public String getMod() {
-        return mod;
+    public String getModulo() {
+        return modulo;
     }
     
 }


### PR DESCRIPTION
Hello guys, I wonder if this is a good feature to consider.

You know the counting problems that eask you to "return answer modulo 1,000,000,007", or sometimes 1,000,000,009 or something. Well, this feature tries to detect that pattern, so you can have the following in template:

${<if Problem.Description.Mod}
    static const int MOD = ${Problem.Description.Mod}; 
${<end}

If the pattern "modulo X" is detected then this will appear in the generated source code. So if problem says "modulo 1,000,000,007", the source code will have:

static const int MOD = 1000000007;

This saves some coding time and also prevents a common mistake (missing a zero in 100000007 or putting 1000000007 when problem asks for 1000000007.

And it automatically adds it. As long as it recognized the pattern correctly. There may be problems in which it doesn't work for some reason, but so far tests work well.
