### PR TITLE
Make notes section appear only when the problem has notes.

### DIFF
--- a/src/main/java/greed/model/ProblemDescription.java
+++ b/src/main/java/greed/model/ProblemDescription.java
@@ -21,6 +21,10 @@ public class ProblemDescription {
     public String[] getNotes() {
         return notes;
     }
+    public boolean getHasNotes() {
+        return (notes.length > 0);
+    }
+    
 
     public String[] getConstraints() {
         return constraints;

--- a/src/main/resources/templates/problem/desc.html.tmpl
+++ b/src/main/resources/templates/problem/desc.html.tmpl
@@ -122,6 +122,7 @@
         </div>
     </div>
 
+    ${<if Problem.Description.HasNotes}
     <!-- Notes -->
     <div class="section">
         <div class="section-title">Notes</div>
@@ -131,6 +132,7 @@
         ${<end}
         </ul>
     </div>
+    ${<end}
 
     <!-- Constraints -->
     <div class="section">


### PR DESCRIPTION
Add a field HasNotes to ProblemDescription, makes default statement template add them conditionally.

I tried to do it by just modifying the tempalte using the first_ and last_ variables from jmte. They randomly fail and do unexpcted stuff depending on then umber of elements in the list. It is very bugged.
