### PR TITLE
Add HTML renderer. "grid" option.

### DIFF
--- a/src/main/java/greed/template/HTMLRenderer.java
+++ b/src/main/java/greed/template/HTMLRenderer.java
@@ -1,0 +1,89 @@
+package greed.template;
+
+import com.floreysoft.jmte.NamedRenderer;
+import com.floreysoft.jmte.RenderFormatInfo;
+
+import java.util.Locale;
+import java.lang.StringBuilder;
+
+import greed.model.Param;
+import greed.model.ParamValue;
+import greed.model.Param;
+import greed.model.Type;
+
+/**
+ * Greed is good! Cheers!
+ */
+public class HTMLRenderer implements NamedRenderer {
+    
+    private String stripQuotes(String v) {
+        if (v.length() >= 2 && v.charAt(0) == '"' && v.charAt(v.length()-1) == '"') {
+            v = "&quot;" + v.substring(1, v.length() - 1) + "&quot;";
+        }
+        return v;
+    }
+    
+    private String renderParamValue(ParamValue pv, String param) {
+        Type t = pv.getParam().getType();
+        if (t.isString()) {
+            if (t.isArray()) {
+                String[] x = pv.getValueList();
+                boolean grid = ( (x. length > 1) && (param != null) && param.equals("grid") );
+                if (grid) {
+                    int s = x[0].length();
+                    boolean good = true;
+                    for (String y: x) {
+                        grid = (grid && (s == y.length()) );
+                    }
+                }
+                StringBuilder sb = new StringBuilder();
+                sb.append("{");
+                for (int i = 0; i < x.length; i++) {
+                    if (i != 0) {
+                        if (grid) {
+                            sb.append(",<br />&nbsp;");
+                        } else {
+                            sb.append(", ");
+                        }
+                    } else if (! grid) {
+                        sb.append(" ");
+                    }
+                    sb.append(stripQuotes(x[i]));
+                }
+                if (! grid) {
+                    sb.append(" ");
+                }
+                sb.append("}");
+                return sb.toString();
+            } else {
+                return stripQuotes(pv.getValue());
+            }
+        }
+        return pv.getValue();
+    }
+    
+    @Override
+    public String render(Object o, String param, Locale locale) {
+        if (o instanceof ParamValue) {
+            return renderParamValue( (ParamValue)o, param);
+        } else if (o instanceof String) {
+            return stripQuotes( (String)o );
+        }
+        return "(No HTML renderer support for object: "+o.toString()+")";
+    }
+
+    @Override
+    public String getName() {
+        return "html";
+    }
+
+    @Override
+    public RenderFormatInfo getFormatInfo() {
+        return null;
+    }
+
+    @Override
+    public Class<?>[] getSupportedClasses() {
+        return new Class<?>[]{ParamValue.class, String.class};
+    }
+}

--- a/src/main/java/greed/template/TemplateEngine.java
+++ b/src/main/java/greed/template/TemplateEngine.java
@@ -20,6 +20,7 @@ public class TemplateEngine {
         if (engine == null)
             engine = new Engine();
         engine.registerNamedRenderer(new StringUtilRenderer());
+        engine.registerNamedRenderer(new HTMLRenderer());
     }
 
     public static void switchLanguage(Language language) {

--- a/src/main/resources/templates/problem/desc.html.tmpl
+++ b/src/main/resources/templates/problem/desc.html.tmpl
@@ -154,13 +154,13 @@
                     ${if first_e}${end}
                     ${<foreach e.Input in}
                         <span class="tag">input</span>
-                        <span class="data"><b>${in.Param.Name}</b>: ${in.Value}</span>
+                        <span class="data"><b>${in.Param.Name}</b>: ${in;html}</span>
                         <br/>
                     ${<end}
                     </div>
                     <div>
                         <span class="tag">output</span>
-                        <span class="data">${e.Output.Value}</span>
+                        <span class="data">${e.Output;html}</span>
                     </div>
                     ${<if e.Annotation}
                     <div style="display: flex;">


### PR DESCRIPTION
Many TopCoder problems use String[] arguments to represent a grid. Like Problem FourBlocks  in SRM 444. They usually have input presented in this format:

<pre>
{"...1.",
 ".1..1"}
</pre>

If one would have liked to see that in a statement generated by greed, maybe it would have been possible with complicated template usage. But there's the issue of whether you really want all String[] values to be formatted this way. An idea for a good compromise is to only do that formatting if all strings in the array have the same length. But that certainly needs code.

I also noticed that when there are strings in the value, the statement template doesn't convert the surrounding quote characters "" to &amp;quot; so we needed a renderer. It is not a bad idea to have an html renderer to render the objects in greed that need to be rendered in an HTML file, and let it have some utilities. So far the ;html renderer has two uses:
- If the object is a text and it is surrounded by "", the quotes are stripped to HTML entities.
- If the object is a ParamValue, it does the same with string value, or the string values inside the array.
- In addition, if you render a ParamValue in using: in;html("grid") and if all the elements of the String[] value have equal length,  it will render String[]s as a grid. This cannot be used in the default template though because multiple lines break the format of the example cases. But modifying (or not) the default statement template is a topic for another day.

TODO: Perhaps ;html on a text object should replace all HTML special characters with entities and not just surrounding ""? This would be VERY important if a problem has argument values that look like XML tags. But those problems are unlikely in topcoder.
