### PR TITLE
Fix failing tests on some windows environments

### DIFF
--- a/src/test/java/greed/util/ExternalSystemTest.java
+++ b/src/test/java/greed/util/ExternalSystemTest.java
@@ -1,12 +1,13 @@
 package greed.util;
 
 import greed.conf.schema.LoggingConfig;
+
+import java.io.File;
+
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.File;
 
 /**
  * Greed is good! Cheers!
@@ -37,6 +38,7 @@ public class ExternalSystemTest {
     public void testCat() {
         // cat with no arguments will hang
         Assume.assumeTrue(!TestUtil.isWindows());
+        // the exit code 143 corresponds to SIGTERM in POSIX, which is sent when we kill the process
         Assert.assertEquals(ExternalSystem.runExternalCommand("cat"), 143);
     }
 

--- a/src/test/java/greed/util/TestUtil.java
+++ b/src/test/java/greed/util/TestUtil.java
@@ -5,6 +5,8 @@ package greed.util;
  */
 public class TestUtil {
     public static boolean isWindows() {
-        return System.getProperty("os.name").contains("win");
+        String osName = System.getProperty("os.name");
+        if (osName == null) return false;	// won't happen, but avoid NPE ...
+        return osName.contains("win") || osName.contains("Windows");
     }
 }


### PR DESCRIPTION
In my workstation (windows 8), `ExternalSystemTest.testCat` fails.

This is because `TestUtil.isWindows()` returns false in windows 8 -- it's now fixed.
