### PR TITLE
Set target java version as 1.6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Go to [Releases](https://github.com/shivawu/topcoder-greed/releases) page.
 
 Quick start
 -----------
-1. Go to [Downloads], and download the single Greed jar
+1. Go to [Downloads], and download the single Greed jar.
+   The binary is compatible with Java 1.6+.
 
 2. Open __Topcoder arena__ -> __Login__ -> __Options__ -> __Editor__ -> __Add__  
 ![Add greed](https://github.com/shivawu/topcoder-greed/wiki/images/Add-Plugin.png)<br/>

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,9 @@ buildscript {
 apply plugin: 'java'
 apply plugin: 'fatjar'
 
+sourceCompatibility = 1.6
+targetCompatibility = 1.6
+
 group = 'greed'
 version = file('version').text.trim()
 


### PR DESCRIPTION
Make sure the built JAR can work in Java 1.6.
(Previously the compatibility was 1.7 if built on JDK 7 -- not usable in JRE 6)
