### PR TITLE
Use ${Contest.Name} directly in codeRoot. Render codeRoot using template

### DIFF
--- a/src/main/java/greed/Greed.java
+++ b/src/main/java/greed/Greed.java
@@ -122,6 +122,11 @@ public class Greed {
             Log.e("Set problem error", e);
         }
     }
+    
+    private String renderedCodeRoot(GreedConfig config)
+    {
+        return TemplateEngine.render(config.getCodeRoot(), currentTemplateModel);
+    }
 
     private void setProblem(Contest contest, Problem problem, Language language, boolean forceOverride) {
         GreedConfig config = Utils.getGreedConfig();
@@ -201,7 +206,7 @@ public class Greed {
 
             // Output to file
             if (template.getOutputFile() != null) {
-                String filePath = config.getCodeRoot() + "/" +
+                String filePath = renderedCodeRoot(config) + "/" +
                         TemplateEngine.render(template.getOutputFile(), currentTemplateModel);
                 String fileFolder = FileSystem.getParentPath(filePath);
                 if (!FileSystem.exists(fileFolder)) {
@@ -257,8 +262,7 @@ public class Greed {
     public String getSource() {
         GreedConfig config = Utils.getGreedConfig();
         LanguageConfig langConfig = config.getLanguage().get(Language.getName(currentLang));
-
-        String filePath = config.getCodeRoot() + "/" +
+        String filePath = renderedCodeRoot(config) + "/" +
                 TemplateEngine.render(langConfig.getTemplateDef().get(langConfig.getSubmitTemplate()).getOutputFile(), currentTemplateModel);
 
         talkingWindow.showLine("Getting source code from " + filePath);

--- a/src/main/resources/default.conf
+++ b/src/main/resources/default.conf
@@ -1,5 +1,5 @@
 greed {
-    codeRoot    = "."
+    codeRoot    = "${Contest.Name}"
 
     logging {
         logLevel    = OFF
@@ -21,23 +21,23 @@ greed {
             }
             source {
                 override = false
-                outputFileName = "${Contest.Name}/${Problem.Name}"
+                outputFileName = "${Problem.Name}"
                 transformers = [ empty-block, cont-blank-line ]
             }
             unittest {
                 override = false
                 templateFile = None
-                outputFileName = "${Contest.Name}/${Problem.Name}Test"
+                outputFileName = "${Problem.Name}Test"
                 transformers = [ empty-block, cont-blank-line ]
             }
             testcase {
                 override = false
-                outputFile = "${Contest.Name}/${Problem.Name}.sample"
+                outputFile = "${Problem.Name}.sample"
                 templateFile = "builtin testcase/testcases.tmpl"
             }
             problem-desc {
                 override = false
-                outputFile = "${Contest.Name}/${Problem.Name}.html"
+                outputFile = "${Problem.Name}.html"
                 templateFile = "builtin problem/desc.html.tmpl"
             }
             dualcolor-test {
@@ -48,7 +48,7 @@ greed {
             }
             dualcolor-tester {
                 override = false
-                outputFileName = "${Contest.Name}/tester"
+                outputFileName = "tester"
                 outputFileExtension = None
                 templateFile = None
                 transformers = [ empty-block, cont-blank-line ]


### PR DESCRIPTION
This is what we decided to do in #82. By making the codeRoot folder set the default template output folder, it will be easier to change the output for all templates.
