### PR TITLE
Backup configuration

### DIFF
--- a/src/main/java/greed/conf/schema/BackupConfig.java
+++ b/src/main/java/greed/conf/schema/BackupConfig.java
@@ -1,0 +1,33 @@
+package greed.conf.schema;
+
+import greed.conf.meta.ConfigObjectClass;
+import greed.conf.meta.Required;
+
+/**
+ * Greed is good! Cheers!
+ */
+@ConfigObjectClass
+public class BackupConfig {
+    @Required
+    private String fileName;
+    
+    @Required
+    private int fileCountLimit;
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+    
+    public String getFileName() {
+        return this.fileName;
+    }
+    
+    public void setFileCountLimit(int fileCountLimit) {
+        this.fileCountLimit = fileCountLimit;
+    }
+    
+    public int getFileCountLimit() {
+        return this.fileCountLimit;
+    }
+
+}

--- a/src/main/java/greed/conf/schema/GreedConfig.java
+++ b/src/main/java/greed/conf/schema/GreedConfig.java
@@ -16,6 +16,9 @@ public class GreedConfig {
 
     @Required
     private LoggingConfig logging;
+    
+    @Required
+    private BackupConfig backup;
 
     @Required
     @MapParam(value = LanguageConfig.class)
@@ -37,6 +40,14 @@ public class GreedConfig {
         this.logging = logging;
     }
 
+    public BackupConfig getBackup() {
+        return backup;
+    }
+
+    public void setBackup(BackupConfig backup) {
+        this.backup = backup;
+    }
+    
     public HashMap<String, LanguageConfig> getLanguage() {
         return language;
     }

--- a/src/main/resources/default.conf
+++ b/src/main/resources/default.conf
@@ -7,6 +7,11 @@ greed {
         logFolder   = Logs
     }
 
+    backup {
+        fileCountLimit = 3
+        fileName = "${GeneratedFileName}.bak.${BackupNumber}"
+    }
+
     shared {
         templateDef {
             test {


### PR DESCRIPTION
I think it is great greed saves backups of files it overrides. But I would like to be able to customize the file name. It would be specially useful to be able to use .filename.bak.0, so that the file is hidden. Let's agree on config syntax.

<pre>
greed {

backup {
   # Replaces the file name format, backup is saved in the same folder as output file.
    fileName = "${GeneratedFileName}.bak.${BackupNumber}"

    # Sets the backup file limit
    fileCountLimit =  3
}

}
</pre>

This reuses the GeneratedFileName that is used for after gen hooks.

It is possible to use folder structures. But backup folder structure needs to be a subfolder of the place where the file is getting generated:

`backup.fileName = "backups/${GeneratedFileName}.${BackupNumber}"`

Works.
