### PR TITLE
Different files, same size

### DIFF
--- a/src/main/java/greed/Greed.java
+++ b/src/main/java/greed/Greed.java
@@ -182,15 +182,6 @@ public class Greed {
             TemplateConfig template = langConfig.getTemplateDef().get(templateName);
             
             currentTemplateModel.put("Options", template.getOptions() );
-            /*if (template.getOptions() != null) {
-                Log.i("TEMPLATE OPTIONS");
-                for (Map.Entry<String, String> entry : template.getOptions().entrySet()) {
-                    String key = entry.getKey();
-                    String value = entry.getValue();
-                    Log.i(": "+key+" -> "+value);
-                }
-            }*/
-
             if (template == null) {
                 talkingWindow.error("Unknown template [" + templateName + "] (ignored)");
                 continue;
@@ -248,16 +239,17 @@ public class Greed {
                     continue;
                 }
                 if (exists) {
-                    if (FileSystem.getSize(filePath) == code.length()) {
-                        talkingWindow.show(" (skipped, same size)");
+                    if (FileSystem.fileEqualToString( filePath, code)) {
+                        talkingWindow.show(" (skipped, files identical)");
                     } else {
                         talkingWindow.show(" (overwrite)");
                         FileSystem.backup(filePath); // Backup the old files
                         FileSystem.writeFile(filePath, code);
                     }
                 }
-                else
+                else {
                     FileSystem.writeFile(filePath, code);
+                }
 
                 if (template.getAfterFileGen() != null) {
                     CommandConfig afterGen = template.getAfterFileGen();

--- a/src/main/java/greed/util/FileSystem.java
+++ b/src/main/java/greed/util/FileSystem.java
@@ -1,6 +1,8 @@
 package greed.util;
 
 import java.io.File;
+import java.io.FileReader;
+import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
@@ -117,5 +119,37 @@ public class FileSystem {
         }
         Log.i(absolutePath+" -> " + getBackupFile(file, i) );
         file.renameTo(  getBackupFile(file, i) );
+    }
+    
+    public static boolean fileEqualToString(String filePath, String s) {
+        if (getSize(filePath) == s.length()) {
+            File f = new File(Configuration.getWorkspace() + "/" + filePath);
+            int i = 0;
+            try {
+                BufferedReader reader = new BufferedReader(new FileReader(f));
+                try {
+                    char[] buf = new char[100];
+                    int numRead = 0;
+                    while ((numRead=reader.read(buf)) != -1) {
+                        for (int j = 0; j < numRead; j++) {
+                            if ( (i >= s.length()) || (s.charAt(i) != buf[j]) ) {
+                                return false;
+                            }
+                            i++;
+                        }
+                    }
+                    if (i < s.length()) {
+                        return false;
+                    }
+                } finally {
+                    reader.close();
+                }
+                return true;
+            } catch (IOException e) {
+                Log.i("IOException");
+                return false;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
When the new file has exactly the same size as the old file, even when override is true, the new file won't be created. This brings issues when the old file somehow managed to be different and have the same size, something that happens usually when you are developing templates.

Some idea:
- Make it compare the file in case the sizes are equal? I guess Greed doesn't already do this due to performance or some other technical reason?
- Since we are already assuming the files are the same, if override is true or the regenerate button is clicked, replace it anyway, just without making a backup. 
  -  If the file truly is equal, it wouldn't matter.
  - If the file isn't equal, then Greed must replace, that's the reason user had override = true or used the regenerate button.
