### PR TITLE
Two more options for dualcolor templates.

### DIFF
--- a/src/main/resources/default.conf
+++ b/src/main/resources/default.conf
@@ -70,9 +70,11 @@ greed {
                 templateFile = None
                 transformers = [ empty-block, cont-blank-line ]
                 options {
-                    compactMode = COMPACT_REPORT
-                    caseTimeOut = "2.00"
-                    singleFile  = false
+                    compactMode          = COMPACT_REPORT
+                    caseTimeOut          = "2.00"
+                    singleFile           = false
+                    disableColors        = false
+                    customTesterLocation = false
                     #(c++ only)
                     runMultipleProcesses = true
                 }

--- a/src/main/resources/templates/dualcolor/README.md
+++ b/src/main/resources/templates/dualcolor/README.md
@@ -51,6 +51,16 @@ greed.shared.templateDef.dualcolor-test.options {
  + `FULL_REPORT`    : The final report has more detail (one line per test case).
  + `ONLY_REPORT`    : That final report is the only thing displayed. (Very compact).
 * `caseTimeOut` : Initial value of the CASE_TIMEOUT constant.
+* `disableColors`: Default is false. Enable this if your terminal cannot display ANSI-C color codes and you'd still like to use the other features.
+* `customTesterLocation`: Eventually, you'd like to use a single tester.cpp / tester.py file for all the problems. Use this if you'd like to change the location of the loaded tester source.
+Example:
+<pre>
+cpp.options.customTesterLocation = "../tester.cpp"
+python.options.customTesterLocation = "../tester.py"
+# no longer need the dualcolor-tester template.
+shared.templates = [dualcolor-test, source, problem-desc ]
+</pre>
+You can find the tester.cpp / tester.py files after generating them for the first time using greed.
 * `singleFile` : Included just in case there are problems making the two files to work. This one puts all the contents of the tester.cpp/tester.py inside the source file. Also need you to do the following tweaks to `templateDef.dualcolor-tester`:
 <pre>
     templateDef.dualcolor-tester.templateFile = None

--- a/src/main/resources/templates/dualcolor/main.cpp.tmpl
+++ b/src/main/resources/templates/dualcolor/main.cpp.tmpl
@@ -1,5 +1,5 @@
 ${-- /*
-    Vexorian's c++ tester template for greed. Version 0.6
+    Vexorian's c++ tester template for greed. Version 0.7
     Part of test template which has many features:
     - Test cases in bracket format for ease of modification.
     - Very small code for the problem file.
@@ -37,6 +37,11 @@ ${-- /*
                        instead of using it separately. Use in case the 
                        requirement for separate file is too complicated to
                        fulfill.
+        * disableColors: false by default. If true it will not use ANSI color codes.
+        * customTesterLocation :
+             false by default. If it instead had a string location, it will
+             include this customTesterLocation instead of "tester.cpp"
+
     (c) 2013 Victor Hugo Soliz Kuncar, ZLIB/LibPNG license 
 */ }
 //------------------------------------------------------------------------------
@@ -56,11 +61,18 @@ ${<end}
 
 //------------------------------------------------------------------------------
 // Tester code:
+${<if Options.disableColors}
+    #define DISABLE_COLORS
+${<end}
     ${if Options.runMultipleProcesses}//${end}#define DISABLE_THREADS
 ${<if Options.singleFile}
-    ${<DualColorTesterCode}
+${<DualColorTesterCode}
+${<else}
+${<if Options.customTesterLocation}
+    #include "${Options.customTesterLocation}"
 ${<else}
     #include "tester.cpp"
+${<end}
 ${<end}
     struct input {
         ${foreach Method.Params p}${p.Type} p${p.Index};${end}

--- a/src/main/resources/templates/dualcolor/main.py.tmpl
+++ b/src/main/resources/templates/dualcolor/main.py.tmpl
@@ -1,5 +1,5 @@
 ${--
-#    Vexorian's c++ tester template for greed. Version 0.6
+#    Vexorian's c++ tester template for greed. Version 0.7
 #    - Test cases in ( [ () ], x / None ) format for ease of modification.
 #    - Very small code for the problem file.
 #    - Requires tester.py. Use dualcolor-tester template.
@@ -16,7 +16,11 @@ ${--
 #                       instead of using it separately. Use in case the 
 #                       requirement for separate file is too complicated to
 #                       fulfill.
-#    
+#        * disableColors: false by default. If true it will not use ANSI color codes.
+#        * customTesterLocation :
+#             false by default. If it instead had a string location, it will
+#             import this customTesterLocation instead of "tester.py
+#
 #    (c) 2013 Victor Hugo Soliz Kuncar, ZLIB/LibPNG license 
 #
 }  
@@ -40,7 +44,14 @@ ${<if Options.singleFile}
 ${<DualColorTesterCode}
 ${<end}
 if __name__ == '__main__':
+${<if Options.customTesterLocation}
+    import imp
+    tester = imp.load_source('tester', '${Options.customTesterLocation}' )
+${<end}
     import sys${if !Options.singleFile}, tester${end}
+${<if Options.disableColors}
+    tester.disableColors()
+${<end}
     ${if !Options.singleFile}tester.${end}run_tests(
         ${Problem.Name}, '${Method.Name}', TEST_CASES, isTestDisabled, 
         ${CreateTime}, ${Problem.Score}, CASE_TIME_OUT, ${if !Options.singleFile}tester.${end}${Options.compactMode}

--- a/src/main/resources/templates/dualcolor/tester.cpp.tmpl
+++ b/src/main/resources/templates/dualcolor/tester.cpp.tmpl
@@ -1,5 +1,5 @@
 /*
-    Vexorian's c++ generic tester. Version 0.6
+    Vexorian's c++ generic tester. Version 0.7
     Part of test template which has many features:
     - Test cases in bracket format for ease of modification.
     - Very small code for the problem file.
@@ -48,14 +48,25 @@ const int    COMPACT_REPORT = 1;
 const int    ONLY_REPORT    = 2;
     
 // Name the color codes:
-const string COLOR_RESET  = "\\033[0m";    
-
-const string BRIGHT_GREEN   = "\\033[1;32m";
-const string BRIGHT_RED     = "\\033[1;31m";
-const string NORMAL_CROSSED = "\\033[0;9;37m";
-const string RED_BACKGROUND = "\\033[1;41m";
-const string NORMAL_FAINT   = "\\033[0;2m";
-const string BRIGHT_CYAN    = "\\033[1;36m";
+#ifdef DISABLE_COLORS
+    const string COLOR_RESET  = "";    
+    
+    const string BRIGHT_GREEN   = "";
+    const string BRIGHT_RED     = "";
+    const string NORMAL_CROSSED = "";
+    const string RED_BACKGROUND = "";
+    const string NORMAL_FAINT   = "";
+    const string BRIGHT_CYAN    = "";
+#else
+    const string COLOR_RESET  = "\\033[0m";    
+    
+    const string BRIGHT_GREEN   = "\\033[1;32m";
+    const string BRIGHT_RED     = "\\033[1;31m";
+    const string NORMAL_CROSSED = "\\033[0;9;37m";
+    const string RED_BACKGROUND = "\\033[1;41m";
+    const string NORMAL_FAINT   = "\\033[0;2m";
+    const string BRIGHT_CYAN    = "\\033[1;36m";
+#endif
 
 // Configuration:
 const string COMMUNICATION_FILE = "/tmp/topcoder_vx_tester_communicate";

--- a/src/main/resources/templates/dualcolor/tester.py.tmpl
+++ b/src/main/resources/templates/dualcolor/tester.py.tmpl
@@ -1,4 +1,4 @@
-# vexorian's Generic Tester example! version 0.6
+# vexorian's Generic Tester example! version 0.7
 #  - Ansi color codes to make output easy to read.
 #  - run_tests needs a lot of arguments... 
 # (c) 2013 Victor Hugo Soliz Kuncar, ZLIB/LibPNG license 
@@ -42,6 +42,21 @@ RESULT_COLOR = {
     '?' : COLOR_RESET,
     'd' : NORMAL_CROSSED,
 }
+
+
+def disableColors():
+    COLOR_RESET  = ''        
+    BRIGHT_GREEN   = ''
+    BRIGHT_RED     = ''
+    NORMAL_CROSSED = ''
+    RED_BACKGROUND = ''
+    NORMAL_FAINT   = ''
+    BRIGHT_CYAN    = ''
+    global GRADE_COLOR
+    GRADE_COLOR = [''] * len(GRADE_COLOR)
+    copy = [x for x in RESULT_COLOR]
+    for x in copy :
+        RESULT_COLOR[x] = ''
 
 
 def colorCode(q):
@@ -188,3 +203,7 @@ def run_tests( problemClass, methodName, testCases, isTestDisabled, createTime, 
     else:
         line = "%s (%s)" % (line, points)
         sys.stdout.write("%s\\n" % line)
+
+
+if __name__ == '__main__':
+    sys.stdout.write("Not supposed to run this")


### PR DESCRIPTION
I am sorry I forgot about these two options when I made the last commit. These two were important ones I always intended to add.
- Users can now disable the color codes in case they cannot use them / don't like them.
- It is possible to change the location of the tester file when calling dualcolor-test.
