### PR TITLE
Add Type support to HTML render.

### DIFF
--- a/src/main/java/greed/code/LanguageManager.java
+++ b/src/main/java/greed/code/LanguageManager.java
@@ -52,6 +52,10 @@ public class LanguageManager {
         return traitMap.get(language);
     }
 
+    public LanguageRenderer getRenderer(Language language) {
+        return rendererMap.get(language);
+    }
+
     public void registerRenderer(Language language, Engine engine) {
         final LanguageRenderer renderer = rendererMap.get(language);
         if (renderer != null) {

--- a/src/main/java/greed/template/TemplateEngine.java
+++ b/src/main/java/greed/template/TemplateEngine.java
@@ -20,12 +20,12 @@ public class TemplateEngine {
         if (engine == null)
             engine = new Engine();
         engine.registerNamedRenderer(new StringUtilRenderer());
-        engine.registerNamedRenderer(new HTMLRenderer());
         engine.registerNamedRenderer(new ContestCategoryRenderer());
     }
 
     public static void switchLanguage(Language language) {
         lazyInit();
+        engine.registerNamedRenderer(new HTMLRenderer(language));
         LanguageManager.getInstance().registerRenderer(language, engine);
     }
 


### PR DESCRIPTION
I was trying to do #112, at least for my custom template. I found that there are issues at least in c++ where `vector<int>` would not render correctly in HTML (need to strip `< >` into `&lt;&gt;`). So I thought I would just add support for Type objects to the HTML renderer...

It turned out to be a complicated task, I had to modify LanguageManager to give access to the language renderer and TemplateEngine to pass the current language to the HTML renderer.

The type renderer works like this:
- `Type;html` : Strips HTML characters from the rendered Type  name if necessary.
- `Type;html(java)` : First renders the type using Java's renderer, then strips HTML characters.
- `Type;html(cpp)` : First renders the type using c++'s renderer, then strips HTML characters.
- (Same with the other language names as defined in Language.java)
