### PR TITLE
Clean problem-desc and styles . Fix fontSize, add noDefaultStyle 

### DIFF
--- a/src/main/resources/template-defs.conf
+++ b/src/main/resources/template-defs.conf
@@ -57,17 +57,19 @@ problem-desc {
         highlightData      = true
         # set to false to disable image resizing:
         resizeImages       = "200px"
+        # If false, does nothing.
+        # If set to a string, the string will be shown before the expected output
+        # E.g: outputPrefix = "Returns: "
+        # Will make it do what TC's problem statement does.
+        outputPrefix       = "Returns: "
         # The favicon, by default we use topcoder's, set to false to disable it.
         favIcon            = "http://www.topcoder.com/i/favicon.ico"
         # A custom CSS. When set to false, it does nothing.
         # If set to a .css path (Example: "../statement.css", it will replace
         # the default HTML style with a call to that external style sheet.
         customStyle        = false
-        # If false, does nothing.
-        # If set to a string, the string will be shown before the expected output
-        # E.g: outputPrefix = "Returns: "
-        # Will make it do what TC's problem statement does.
-        outputPrefix       = false
+        # disable all CSS that is added by default, using only the custom style specified above
+        noDefaultStyle     = false
     }
 }
 problem-desc-styles             { templateFile = builtin(problem/default.css) }

--- a/src/main/resources/templates/problem/blue.theme.css
+++ b/src/main/resources/templates/problem/blue.theme.css
@@ -1,4 +1,14 @@
-body { color: white; background-color: #001B35; }
-.section .section-title { color: white; }
-ol.testcases > li:before { border-color: #88F; color: white; }
-li.testcase .data { background: #001930;  }
+body {
+    /* font color */
+    color: white;
+    /* background color */
+    background-color: #001B35;
+}
+.section .section-title {
+    /* title color */
+    color: white;
+}
+li.testcase .data {
+    /* highlight color (if highlightData is enabled in options) */
+    background: #001930;
+}

--- a/src/main/resources/templates/problem/dark.theme.css
+++ b/src/main/resources/templates/problem/dark.theme.css
@@ -1,4 +1,14 @@
-body { color: white; background-color: black; }
-.section .section-title { color: white; }
-ol.testcases > li:before { border-color: #181818; color: white; background: #101010; }
-li.testcase .data { background: #050505; }
+body {
+    /* font color */
+    color: #f0f0f0;
+    /* background color */
+    background-color: #0c0c0c;
+}
+.section .section-title {
+    /* title color */
+    color: #f8f8f8;
+}
+li.testcase .data {
+    /* highlight color (if highlightData is enabled in options) */
+    background: #141414;
+}

--- a/src/main/resources/templates/problem/default.css
+++ b/src/main/resources/templates/problem/default.css
@@ -1,7 +1,6 @@
 /* font */
 body, ul.constraints > li:before, ul.notes > li:before {
     font-family: Helvetica, Arial, Verdana, sans-serif;
-    font-size: ;
     line-height: 1.2em;
 }
 ul.constraints > li:before, ul.notes > li:before {
@@ -78,8 +77,6 @@ li.testcase .testcase-comment {
 
 li.testcase .testcase-content {
     margin: 0.31em;
-}
-.testcase-content .variables {
 }
 .variables {
     margin-left: 0.5em;

--- a/src/main/resources/templates/problem/desc.html.tmpl
+++ b/src/main/resources/templates/problem/desc.html.tmpl
@@ -15,8 +15,11 @@
     <style type="text/css">
         ${Options.theme;seq(format(Dependencies.problem-desc-theme-%s.Output), reify)}
     </style>
-
+    ${if !Options.noDefaultStyle}
     <style type="text/css">
+        body, ul.constraints > li:before, ul.notes > li:before {
+            font-size: ${Options.fontSize};
+        }
         ${if Options.resizeImages}
         img {
             float: none;
@@ -62,6 +65,7 @@
         }
         ${end}
     </style>
+    ${end}
 
     ${if Options.customStyle}
     <link href="${Options.customStyle}" rel="stylesheet" type="text/css" />

--- a/src/main/resources/templates/problem/light.theme.css
+++ b/src/main/resources/templates/problem/light.theme.css
@@ -1,4 +1,14 @@
-body { color: #333333; background-color: white; }
-.section .section-title { color: black; }
-ol.testcases > li:before { border-color: #ddd; color: grey; }
-li.testcase .data { background: #eee; }
+body {
+    /* font color */
+    color: #333333;
+    /* background color */
+    background-color: white;
+}
+.section .section-title {
+    /* title color */
+    color: black;
+}
+li.testcase .data {
+    /* highlight color (if highlightData is enabled in options) */
+    background: #eee;
+}

--- a/src/main/resources/templates/problem/lowcontrast.theme.css
+++ b/src/main/resources/templates/problem/lowcontrast.theme.css
@@ -1,4 +1,14 @@
-body { color: #CCCCCC; background-color: #333333; }
-.section .section-title { color: white; }
-ol.testcases > li:before { border-color: #888; color: #CCCCCC; }
-li.testcase .data { background: #303030; }
+body {
+    /* font color */
+    color: #CCCCCC;
+    /* background color */
+    background-color: #333333;
+}
+.section .section-title {
+    /* title color */
+    color: white;
+}
+li.testcase .data {
+    /* highlight color (if highlightData is enabled in options) */
+    background: #303030;
+}


### PR DESCRIPTION
- Now that there are no tags, I think it is best to prefix output with Returns: as we need to differentiate input and output and that's the way the arena does it.
- fontSize CSS needs to be in the main template for the option to work.
- Removed the color settings for the fancy example numbers from the themes.
- Now that the color themes are separate templates, I cleaned them up and added comments to encourage users to make their own.
- Added a noDefaultStyle option. The old customStyleSheet replaced the whole style sheet, but now customStyle doesn't . I think it is useful to allow users to add style, but I also need to make it possible to remove all style from HTML (I like to use an external CSS file I can modify) so this function disables all style inside the html.
