### PR TITLE
Set Locale to US

### DIFF
--- a/src/main/java/greed/template/FormatRenderer.java
+++ b/src/main/java/greed/template/FormatRenderer.java
@@ -12,7 +12,7 @@ public class FormatRenderer implements NamedRenderer {
 
     @Override
     public String render(Object o, String s, Locale locale) {
-        return String.format(s, o);
+        return String.format(Locale.US, s, o);
     }
 
     @Override


### PR DESCRIPTION
Currently when floats are rendered in my computer, they use `2,000`. Although this is the way the arena is currently doing it, it has been called a bug : http://apps.topcoder.com/forums/module=Message&messageID=1824120 

Since the rest of the problem statement uses US formatting, it is best for the time limit to use it too. 

For code we'll need a formatter / locale that is ensured to give code-friendly numbers. Locale.US might work, I think.
