### PR TITLE
Add line height to test case data.

### DIFF
--- a/src/main/resources/templates/problem/default.css
+++ b/src/main/resources/templates/problem/default.css
@@ -26,6 +26,7 @@ type {
 }
 li.testcase .data {
     font-family: monospace;
+    line-height: 1.5em;
 }
 
 /* other style */


### PR DESCRIPTION
This is necessary else the highlight background color overlaps with the text of the above line when the test case data takes multiple lines.

I think a regression removed this height setting.
