### PR TITLE
Add (invisible by default) tag markup.

### DIFF
--- a/src/main/resources/templates/problem/desc.html.tmpl
+++ b/src/main/resources/templates/problem/desc.html.tmpl
@@ -55,7 +55,7 @@
         
         ${if !Options.showVariableNames}.variable .name,${end}
         ${if !Options.showDefinition}#definition,${end}
-        .hideit {
+        .tag {
             visibility: hidden;
             position: absolute;
         }
@@ -188,6 +188,7 @@
             <li class="testcase">
                 <div class="testcase-content">
                     <div class="testcase-input">
+                        <div class='tag'>input</div>
                         <ul class="variables">
                         ${foreach e.Input in}
                             <li class="variable">
@@ -204,6 +205,7 @@
                         </ul>
                     </div>
                     <div class="testcase-output">
+                        <div class='tag'>output</div>
                         <span class="value data">
                         ${if Options.gridArrays}
                             ${e.Output;html(grid)}
@@ -214,6 +216,7 @@
                     </div>
                     ${if e.Annotation}
                     <div class="testcase-annotation">
+                        <div class='tag'>note</div>
                         <div class="testcase-comment">${e.Annotation}</div>
                     </div>
                     ${end}


### PR DESCRIPTION
This readds the tag divs as markup but leaves them invisible. This way people can make use of these tags in the markup when customizing the CSS without having to edit the html.
