### PR TITLE
Further problem-desc cleanup.

### DIFF
--- a/src/main/resources/default.conf
+++ b/src/main/resources/default.conf
@@ -46,6 +46,7 @@ greed {
                 dualcolor-tester.outputFileExtension = cpp
                 source.templateFile = builtin(source/cpp.tmpl)
                 source.outputFileExtension = cpp
+                problem-desc.options.showDefinition = cpp
             }
         }
 
@@ -57,6 +58,7 @@ greed {
                 source.outputFileExtension = java
                 unittest.templateFile = builtin(unittest/junit.java.tmpl)
                 unittest.outputFileExtension = java
+                problem-desc.options.showDefinition = java
             }
         }
 
@@ -68,6 +70,7 @@ greed {
                 source.outputFileExtension = cs
                 unittest.templateFile = builtin(unittest/nunit.cs.tmpl)
                 unittest.outputFileExtension = cs
+                problem-desc.options.showDefinition = csharp
             }
         }
 
@@ -83,6 +86,7 @@ greed {
                 dualcolor-tester.outputFileExtension = py
                 source.templateFile = builtin(source/py.tmpl)
                 source.outputFileExtension = py
+                problem-desc.options.showDefinition = python
             }
 
         }

--- a/src/main/resources/template-defs.conf
+++ b/src/main/resources/template-defs.conf
@@ -46,29 +46,15 @@ problem-desc {
         theme              = light
         # shows String[]s with rectangular dimensions as a grid.
         gridArrays         = false
-        # Show problem definition (method signature description, etc)
-        showDefinition     = true
-        forceDefLanguage   = false
-        # The base font size. Statement scales up or down based on this value:
-        fontSize           = "16px"
-        # Show argument names before their values in examples section:
-        showVariableNames  = true
-        # By default, test case data is highlighted by special background:
-        highlightData      = true
-        # set to false to disable image resizing:
-        resizeImages       = "200px"
-        # If false, does nothing.
-        # If set to a string, the string will be shown before the expected output
-        # E.g: outputPrefix = "Returns: "
-        # Will make it do what TC's problem statement does.
-        outputPrefix       = "Returns: "
+        # Show problem definition (false, cpp, java, python...)
+        # In default.conf each language template definition sets this setting to its own by default
+        showDefinition     = java
         # The favicon, by default we use topcoder's, set to false to disable it.
         favIcon            = "http://www.topcoder.com/i/favicon.ico"
         # A custom CSS. When set to false, it does nothing.
-        # If set to a .css path (Example: "../statement.css", it will replace
-        # the default HTML style with a call to that external style sheet.
+        # If set to a .css path (Example: "../statement.css", it will call that external style sheet.
         customStyle        = false
-        # disable all CSS that is added by default, using only the custom style specified above
+        # disable all CSS that is added by default, using only the custom style specified by customStyle.
         noDefaultStyle     = false
     }
 }

--- a/src/main/resources/templates/problem/blue.theme.css
+++ b/src/main/resources/templates/problem/blue.theme.css
@@ -9,6 +9,6 @@ body {
     color: white;
 }
 li.testcase .data {
-    /* highlight color (if highlightData is enabled in options) */
+    /* highlight color */
     background: #001930;
 }

--- a/src/main/resources/templates/problem/dark.theme.css
+++ b/src/main/resources/templates/problem/dark.theme.css
@@ -9,6 +9,6 @@ body {
     color: #f8f8f8;
 }
 li.testcase .data {
-    /* highlight color (if highlightData is enabled in options) */
+    /* highlight color */
     background: #141414;
 }

--- a/src/main/resources/templates/problem/default.css
+++ b/src/main/resources/templates/problem/default.css
@@ -1,6 +1,7 @@
 /* font */
-body, ul.constraints > li:before, ul.notes > li:before {
+body {
     font-family: Helvetica, Arial, Verdana, sans-serif;
+    font-size: 16px;
     line-height: 1.2em;
 }
 ul.constraints > li:before, ul.notes > li:before {
@@ -28,7 +29,7 @@ li.testcase .data {
     line-height: 1.5em;
 }
 
-/* other style */
+/* layout */
 .heading {
     margin-top: 0.1em;
     margin-bottom:0.1em;
@@ -157,3 +158,26 @@ ol.testcases > li:before {
 #problem-name {
     display: block;
 }
+
+.variable .name .data {
+    border-top-left-radius: 0.5em;
+    border-bottom-left-radius: 0.5em;
+    padding: 0.2em 0em 0.2em 1em;
+}
+.variable .value .data {
+    border-top-right-radius: 0.5em;
+    border-bottom-right-radius: 0.5em;
+    padding: 0.2em 1em 0.2em 0.5em;
+}
+.testcase-output .data {
+    border-radius: 0.5em;
+    padding: 0.2em 1em 0.2em 1em;
+}
+.testcase-output .value:before {
+    content: "Returns: ";
+}
+.tag {
+    visibility: hidden;
+    position: absolute;
+}
+

--- a/src/main/resources/templates/problem/desc.html.tmpl
+++ b/src/main/resources/templates/problem/desc.html.tmpl
@@ -8,65 +8,13 @@
     <link type="image/x-icon" rel="shortcut icon" href="${Options.favIcon}"/>
     ${end}
 
-    <style type="text/css">
-        ${Dependencies.problem-desc-styles.Output}
-    </style>
-
-    <style type="text/css">
-        ${Options.theme;seq(format(Dependencies.problem-desc-theme-%s.Output), reify)}
-    </style>
     ${if !Options.noDefaultStyle}
     <style type="text/css">
-        body, ul.constraints > li:before, ul.notes > li:before {
-            font-size: ${Options.fontSize};
-        }
-        ${if Options.resizeImages}
-        img {
-            float: none;
-            display: block;
-            width: ${Options.resizeImages};
-            height: auto;
-            margin: 0.615em;
-            border: 0px solid #ccc;
-        }
-        ${end}
-
-        ${if Options.showVariableNames}
-        .variable .name .data {
-            border-top-left-radius: 0.5em;
-            border-bottom-left-radius: 0.5em;
-            padding: 0.2em 0em 0.2em 1em;
-        }
-        .variable .value .data {
-            border-top-right-radius: 0.5em;
-            border-bottom-right-radius: 0.5em;
-            padding: 0.2em 1em 0.2em 0.5em;
-        }
-        ${else}.variable .value .data, ${end}
-        .testcase-output .data {
-            border-radius: 0.5em;
-            padding: 0.2em 1em 0.2em 1em;
-        }
-        ${if !Options.highlightData}
-        .data {
-            background: inherit !important;
-        }
-        ${end}
-        
-        ${if !Options.showVariableNames}.variable .name,${end}
-        ${if !Options.showDefinition}#definition,${end}
-        .tag {
-            visibility: hidden;
-            position: absolute;
-        }
-        ${if Options.outputPrefix}
-        .testcase-output .value:before {
-            content: "${Options.outputPrefix}";
-        }
-        ${end}
+        ${Dependencies.problem-desc-styles.Output}
+        ${Options.theme;seq(format(Dependencies.problem-desc-theme-%s.Output), reify)}
     </style>
     ${end}
-
+    
     ${if Options.customStyle}
     <link href="${Options.customStyle}" rel="stylesheet" type="text/css" />
     ${end}
@@ -92,6 +40,7 @@
     </div>
     
     <!-- Problem definition -->
+    ${if Options.showDefinition}
     <div class="section" id="definition">
         <h2 class="section-title">Definition</h2>
         <div class="problem-definition">
@@ -108,38 +57,27 @@
                     <span class='definition-name'>Parameters</span>
                     <span class='definition-value'>
                     ${foreach Method.Params p , }
-                        ${if Options.forceDefLanguage}
-                            ${p.Type;seq(html($Options.forceDefLanguage))}
-                        ${else}
-                            ${p.Type;seq(#, html)}
-                        ${end}
+                        ${p.Type;seq(html($Options.showDefinition))}
                     ${end}
                     </span>
                 </li>
                 <li class="definition-line" id='returns-line'>
                     <span class='definition-name'>Returns</span>
                     <span class='definition-value'>
-                        ${if Options.forceDefLanguage}
-                            ${Method.ReturnType;seq(html($Options.forceDefLanguage))}
-                        ${else}
-                            ${Method.ReturnType;seq(#, html)}
-                        ${end}
+                        ${Method.ReturnType;seq(html($Options.showDefinition))}
                     </span>
                 </li>
                 <li class="definition-line" id='signature-line'>
                     <span class='definition-name'>Method signature</span>
                     <span class='definition-value'>
-                        ${if Options.forceDefLanguage}
-                            ${Method;seq(html($Options.forceDefLanguage))}
-                        ${else}
-                            ${Method;seq(#, html)}
-                        ${end}
+                        ${Method;seq(html($Options.showDefinition))}
                     </span>
                 </li>
             </ul>
             <div class="problem-definition-public-tip">(be sure your method is public)</div>
         </div>        
     </div>
+    ${end}
 
     <!-- Limits -->
     <div class="section">

--- a/src/main/resources/templates/problem/light.theme.css
+++ b/src/main/resources/templates/problem/light.theme.css
@@ -9,6 +9,6 @@ body {
     color: black;
 }
 li.testcase .data {
-    /* highlight color (if highlightData is enabled in options) */
+    /* highlight color */
     background: #eee;
 }

--- a/src/main/resources/templates/problem/lowcontrast.theme.css
+++ b/src/main/resources/templates/problem/lowcontrast.theme.css
@@ -9,6 +9,6 @@ body {
     color: white;
 }
 li.testcase .data {
-    /* highlight color (if highlightData is enabled in options) */
+    /* highlight color */
     background: #303030;
 }


### PR DESCRIPTION
- Removed all options that can be easily done through HTML: hiding variable names, uses Returns: by default, doesn't resize images, font-size is 16px.
- Merged showDefinition and forceDefLanguage. Although current implementation of this merge was complicated (could use some tweaks in the html renderer so that a `default` setting is possible).
- As a result, there is no CSS in problem-desc-tmpl
