### PR TITLE
Fix grid. Further HTML cleanup and tweaks.

### DIFF
--- a/src/main/resources/templates/problem/default.css
+++ b/src/main/resources/templates/problem/default.css
@@ -82,19 +82,10 @@ li.testcase .testcase-content {
 }
 
 /* Data and variables */
-.variable .name .data {
-    padding: 0.2em 0em 0.2em 1em;
+.testcase-output {
+    padding: 0.2em 1em 0.2em 0em;
 }
-.variable .value .data {
-    padding: 0.2em 1em 0.2em 0.5em;
-}
-.testcase-output .data {
-    padding: 0.2em 1em 0.2em 1em;
-}
-.testcase-output .value:before {
-    content: "Returns: ";
-}
-.variables {
+.variables, .testcase-output {
     margin-left: 0.5em;
     display: table;
     margin-bottom: 0px;
@@ -104,20 +95,27 @@ li.testcase .testcase-content {
     display: table-row;
 }
 .variable .name {
+    padding: 0.2em 0em 0.2em 1em;
     font-weight: bold;
     display: table-cell;
     text-align: right;
 }
-.variable .name .data:after {
-    font-weight: bold;
-    content : ": ";
-}
-.variable .value {
+.testcase-output .prefix {
+    padding: 0.2em 0em 0.2em 1em;
     display: table-cell;
 }
-.testcase-content .testcase-output .value {
-    margin-left: 0.5em;
-    width: auto;
+.testcase-output .prefix:after {
+    content : ":";
+    padding-right: 0.5em;
+}
+.variable .name:after {
+    font-weight: bold;
+    content : ":";
+    padding-right: 0.5em;
+}
+.variable .value, .testcase-output .value {
+    padding: 0.2em 1em 0.2em 0em;
+    display: table-cell;
 }
 ol.testcases {
     padding: 0px;

--- a/src/main/resources/templates/problem/desc.html.tmpl
+++ b/src/main/resources/templates/problem/desc.html.tmpl
@@ -130,20 +130,21 @@
                         <ul class="variables">
                         ${foreach e.Input in}
                             <li class="variable data">
-                                <span class="name"><span class='data'>${in.Param.Name}</span></span>
-                                <span class="value"><span class='data'>
+                                <span class="name data">${in.Param.Name}</span>
+                                <span class="value data">
                                 ${if Options.gridArrays}
                                     ${in;html(grid)}
                                 ${else}
                                     ${in;html}
                                 ${end}
-                                </span></span>
+                                </span>
                             </li>
                         ${end}
                         </ul>
                     </div>
                     <div class="testcase-output">
                         <div class='tag'>output</div>
+                        <span class="prefix data">Returns</span>
                         <span class="value data">
                         ${if Options.gridArrays}
                             ${e.Output;html(grid)}


### PR DESCRIPTION
In #127, @ashashwat reported a regression with the grid option in HTML renderer. The bug was actually because of HTML, or rather, span tags don't support padding when using multiple lines. I made some further fixes, discovered similar issues with output, also noticed changes @shivawu made to the template, after these changes, further cleanup to the CSS was possible. But I also modified the `"Returns:"` part to use a tag instead of CSS.
