### PR TITLE
If api's timelimit is 840000, return 2000.

### DIFF
--- a/src/main/java/greed/model/Convert.java
+++ b/src/main/java/greed/model/Convert.java
@@ -9,6 +9,9 @@ import greed.code.LanguageTrait;
  * Greed is good! Cheers!
  */
 public class Convert {
+    private static final int DUMMY_TIME_LIMIT   = 840000;
+    private static final int DEFAULT_TIME_LIMIT = 2000;
+    
     public static Contest convertContest(com.topcoder.client.contestant.ProblemComponentModel problem) {
         String fullName = problem.getProblem().getRound().getContestName();
         boolean hasDivision = fullName.contains("DIV");
@@ -109,6 +112,9 @@ public class Convert {
 
         int memoryLimitMB = problem.getComponent().getMemLimitMB();
         int timeLimitMillis = problem.getComponent().getExecutionTimeLimit();
+        if (timeLimitMillis >= DUMMY_TIME_LIMIT) {
+            timeLimitMillis = DEFAULT_TIME_LIMIT;
+        }
 
         return new Problem(
                 problem.getProblem().getName(),


### PR DESCRIPTION
Turns out that the arena returns 840000 milliseconds in old problems , where the supposed value is 2000. 840000 is probably some magic number TC uses to mark a default not existing. For now it is best to use this if-then-else. It is very unlikely a new problem appears that really has a 840 seconds time limit.
