### PR TITLE
Detect all entities when double-escaped

### DIFF
--- a/src/main/java/greed/model/Convert.java
+++ b/src/main/java/greed/model/Convert.java
@@ -68,7 +68,7 @@ public class Convert {
     {
         // TopCoder's toXML() has the bad habit of doubly stripping entites.
         // For example, &gt; becomes &amp;gt;
-        String s = tcXML.replaceAll("&amp;(lt|gt|amp|quot|apos);", "&$1;");
+        String s = tcXML.replaceAll("&amp;((#[0-9]+)|([a-zA-Z]+));", "&$1;");
         
         // We need to replace <br></br> with <br />. This fixes the 
         // double line break issue that happens in some problem statements. 


### PR DESCRIPTION
This should solve #130 .

In the past, the list of HTML entities that were detected to be escaped twice were limited to some 6 usual ones. This version handles all HTML entities according to the HTML language. That is any string that matches: `&someword;` or `&#somenumber;`
