### PR TITLE
Fix float comparison bugs in unit tests

### DIFF
--- a/src/main/resources/templates/unittest/junit.java.tmpl
+++ b/src/main/resources/templates/unittest/junit.java.tmpl
@@ -1,7 +1,28 @@
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.*;
 
 public class ${ClassName}Test {
+${<if Method.ReturnType.RealNumber}
+
+	static void assertTcFloatEquals(double expected, double actual) {
+		double eps = 1e-9;
+		if (Double.isNaN(expected) || Double.isNaN(actual)
+		    || Math.abs(expected - actual) > eps * Math.max(1.0, Math.abs(expected))) {
+			throw new ComparisonFailure(null, String.valueOf(expected), String.valueOf(actual));
+		}
+	}
+
+${<if Method.ReturnType.Array}
+	static void assertTcFloatArrayEquals(double[] expected, double[] actual) {
+		new org.junit.internal.ComparisonCriteria() {
+			@Override
+			protected void assertElementsEqual(Object expected, Object actual) {
+				assertTcFloatEquals((Double) expected, (Double) actual);
+			}
+		}.arrayEquals(null, expected, actual);
+	}
+
+${<end}
+${<end}
 ${<foreach Examples e}
 	@Test
 	public void example${e.Num}()
@@ -24,14 +45,18 @@ ${<else}
 ${<end}
 	
 		${Method.ReturnType} __result = new ${ClassName}().${Method.Name}(${foreach e.Input in , }${in.Param.Name}${end});
-		
-${<if Method.ReturnType.RealNumber}
-		Assert.assertEquals(__expected, __result, 1e-9);
-${<else}
-${<if ReturnsArray}
+
+${<if !Method.ReturnType.RealNumber}
+${<if Method.ReturnType.Array}
 		Assert.assertArrayEquals(__expected, __result);
 ${<else}
 		Assert.assertEquals(__expected, __result);
+${<end}
+${<else}
+${<if Method.ReturnType.Array}
+		assertTcFloatArrayEquals(__expected, __result);
+${<else}
+		assertTcFloatEquals(__expected, __result);
 ${<end}
 ${<end}
 	}

--- a/src/main/resources/templates/unittest/nunit.cs.tmpl
+++ b/src/main/resources/templates/unittest/nunit.cs.tmpl
@@ -1,13 +1,30 @@
+using System;
 using NUnit.Framework;
 
 [TestFixture]
 public class ${ClassName}Test
 {
 ${<if Method.ReturnType.RealNumber}
-	[SetUp]
-	public void Setup()
+	class TcDoubleEqualityComparer : System.Collections.Generic.IEqualityComparer<double>
 	{
-		GlobalSettings.DefaultFloatingPointTolerance = 1e-9;
+		public bool Equals(double x, double y)
+		{
+			double eps = 1e-9;
+			return
+				!double.IsNaN(x) && !double.IsNaN(y)
+				&& Math.Abs(x - y) <= eps*Math.Max(1.0, Math.Min(Math.Abs(x), Math.Abs(y)));
+		}
+
+		public int GetHashCode(double obj)
+		{
+			// Not relevant
+			throw new NotImplementedException();
+		}
+	}
+
+	private static void AssertTcEqualTo<T>(T expected, T actual)
+	{
+		Assert.That(actual, Is.EqualTo(expected).Using(new TcDoubleEqualityComparer()));
 	}
 
 ${<end}
@@ -32,7 +49,11 @@ ${<else}
 		};
 ${<end}
 		${Method.ReturnType} __result = new ${ClassName}().${Method.Name}(${foreach e.Input in , }${in.Param.Name}${end});
+${<if Method.ReturnType.RealNumber}
+		AssertTcEqualTo(__expected, __result);
+${<else}
 		Assert.AreEqual(__expected, __result);
+${<end}
 	}
 
 ${<end}

--- a/src/main/resources/templates/unittest/unittest.py.tmpl
+++ b/src/main/resources/templates/unittest/unittest.py.tmpl
@@ -1,8 +1,26 @@
 import unittest
+import math
 from ${ClassName} import ${ClassName}
 
 
 class ${ClassName}Test(unittest.TestCase):
+${<if Method.ReturnType.RealNumber}
+
+    def assertTcFloatEqual(self, expected, received, msg=None):
+        eps = 1e-9
+        if math.isnan(received) or math.isnan(expected) \\
+           or abs(received - expected) > eps * max(1.0, abs(expected)):
+            msg = self._formatMessage(msg, "%s != %s" % (expected, received))
+            raise self.failureException(msg)
+${<if Method.ReturnType.Array}
+
+    def assertTcFloatListEqual(self, expected, received):
+        if len(expected) != len(received):
+            raise self.failureException("%s != %s (different length)" % (expected, received))
+        for i, (f1, f2) in enumerate(zip(expected, received)):
+            self.assertTcFloatEqual(f1, f2, "%s != %s at index %s" % (expected, received, i))
+${<end}
+${<end}
 ${<foreach Examples e}
 
     def test_Example${e.Num}(self):
@@ -26,7 +44,11 @@ ${<end}
 ${<if !Method.ReturnType.RealNumber}
         self.assertEqual(__expected, __result)
 ${<else}
-        self.assertAlmostEqual(__expected, __result, delta=1e-9)
+${<if Method.ReturnType.Array}
+        self.assertTcFloatListEqual(__expected, __result)
+${<else}
+        self.assertTcFloatEqual(__expected, __result)
+${<end}
 ${<end}
 ${<end}
 


### PR DESCRIPTION
See discussions in #133. Tested with SRM417 "TripleJump" and SRM171 "ResistorCombinations".
