### PR TITLE
Temporary fix to #139.

### DIFF
--- a/src/main/java/greed/model/Convert.java
+++ b/src/main/java/greed/model/Convert.java
@@ -111,7 +111,13 @@ public class Convert {
             constraints[i] = commonTCXMLFixes(problem.getConstraints()[i].toXML());
 
         int memoryLimitMB = problem.getComponent().getMemLimitMB();
-        int timeLimitMillis = problem.getComponent().getExecutionTimeLimit();
+        int timeLimitMillis;
+        try {
+            timeLimitMillis = problem.getComponent().getExecutionTimeLimit();
+        } catch (Throwable e) {
+            greed.util.Log.e("getExecutionTimeLimit() method not found. Using default time limit.");
+            timeLimitMillis = DEFAULT_TIME_LIMIT;
+        }
         if (timeLimitMillis >= DUMMY_TIME_LIMIT) {
             timeLimitMillis = DEFAULT_TIME_LIMIT;
         }


### PR DESCRIPTION
Topcoder arena regression removed the getExecutionTimeLimit() method from ProblemComponent. This is causing issue #139. The PR detects the NoSuchMethodError and in that case uses DEFAULT_TIME_LIMIT (2000). Hopefully, when the arena maintainers re-add the time limit method, Greed will once again  be able to correctly detect the time limit.
