### PR TITLE
Change the default value of testcase.overwrite to 'force'

### DIFF
--- a/src/main/resources/template-defs.conf
+++ b/src/main/resources/template-defs.conf
@@ -24,7 +24,7 @@ unittest {
     transformers = [ empty-block, cont-blank-line ]
 }
 testcase {
-    overwrite = skip
+    overwrite = force
     outputFile = "${Problem.Name}.sample"
     templateFile = builtin(testcase/testcases.tmpl)
 }


### PR DESCRIPTION
Python raised ValueError while reading a sample input because int() cannot parse long integers with 'L' like '1L'.

Values are printed as-is in PythonLanguage#renderParamValue(). However, Java is selected first in topcoder arena. Therefore, long integers are printed with 'L' in JavaLanguage#renderParamValue(). Though I changed language to Python in arena, *.sample file was not updated.

To fix this issue, the default value of testcase.overwrite should be 'force'.
