### PR TITLE
Trim leading/trailing spaces from contest name.

### DIFF
--- a/src/main/java/greed/model/Convert.java
+++ b/src/main/java/greed/model/Convert.java
@@ -13,7 +13,7 @@ public class Convert {
     private static final int DEFAULT_TIME_LIMIT = 2000;
     
     public static Contest convertContest(com.topcoder.client.contestant.ProblemComponentModel problem) {
-        String fullName = problem.getProblem().getRound().getContestName();
+        String fullName = problem.getProblem().getRound().getContestName().trim();
         boolean hasDivision = fullName.contains("DIV");
         Integer div = null;
         String contestName;


### PR DESCRIPTION
For some reason, contest "TCO06 Round 2 " has a trailing space. This caused problems generating files from the templates because Windows removes trailing spaces when creating a folder, so the folder "TCO06 Round 2 /" could not be found.
