### PR TITLE
update c++ template code, include more header files

### DIFF
--- a/src/main/resources/templates/source/cpp.tmpl
+++ b/src/main/resources/templates/source/cpp.tmpl
@@ -1,14 +1,28 @@
+#include <algorithm>
+#include <functional>
+#include <numeric>
+#include <utility>
+#include <iostream>
+#include <sstream>
+#include <iomanip>
+
+#include <bitset>
+#include <string>
+#include <vector>
+#include <stack>
+#include <deque>
+#include <queue>
+#include <set>
+#include <map>
+
 #include <cstdio>
+#include <cstdlib>
+#include <cctype>
 #include <cmath>
 #include <cstring>
 #include <ctime>
-#include <iostream>
-#include <algorithm>
-#include <set>
-#include <vector>
-#include <sstream>
-#include <typeinfo>
-#include <fstream>
+#include <climits>
+
 
 using namespace std;
 


### PR DESCRIPTION
queue and map are used frequently in TopCoder's algorithm competition，so I think it's better to include their header file in default template.
