### PR TITLE
Always trim first when parsing params.

### DIFF
--- a/src/main/java/greed/code/lang/AbstractLanguage.java
+++ b/src/main/java/greed/code/lang/AbstractLanguage.java
@@ -27,10 +27,11 @@ public abstract class AbstractLanguage implements LanguageTrait, LanguageRendere
 
     @Override
     public ParamValue parseValue(String value, Param param) {
+        value = value.trim(); // always trim first
+        
         if (!param.getType().isArray())
             return new ParamValue(param, value);
 
-        value = value.trim();
         value = value.substring(1, value.length() - 1);
         value = value.replaceAll("\n", "");
         value = value.trim(); //need a second trim in case it is an empty list {  }


### PR DESCRIPTION
Sometimes even a simple string param may have redundant spaces like sample 2 in BagAndCards (SRM 679). Always trim first when parsing params will fix this.

The incorrect `BagAndCards.sample` is given below. Note that there is a trailing space in sample 2.

I have debugged my solution for quite a while and found this bug in Greed during the contest...QQ

```
-- Example 0
2
4
1
1
0
0
NNYYNYN

9
-- Example 1
3
5
1
1
1
2
NNYYNYNYN

1532
-- Example 2
10
20
111
222
333
444
"NNNNNYYYNNNYYYYYYNNYYYYNNNNYNNYYYNNNYYN" 

450750683
-- Example 3
2
2
1
1
0
0
NNY

1
```