### PR TITLE
changed variable data -> _greed_data

### DIFF
--- a/src/main/resources/templates/filetest/cpp.tmpl
+++ b/src/main/resources/templates/filetest/cpp.tmpl
@@ -1,8 +1,8 @@
-ifstream data("${Dependencies.testcase.GeneratedFileName}");
+ifstream _greed_data("${Dependencies.testcase.GeneratedFileName}");
 
 string next_line() {
     string s;
-    getline(data, s);
+    getline(_greed_data, s);
     return s;
 }
 


### PR DESCRIPTION
Variable name 'data' crashes within the same namespace std, in Apple LLVM version 8.0.0 (clang-800.0.42.1)