### PR TITLE
Fix contest category for those contests that have the name 'TCO SRM' for some reason

### DIFF
--- a/src/main/java/greed/template/ContestCategoryRenderer.java
+++ b/src/main/java/greed/template/ContestCategoryRenderer.java
@@ -88,7 +88,7 @@ public class ContestCategoryRenderer implements NamedRenderer {
         String result = c.getName();
         if (result.contains("TCHS")) {
             result = text.get( CATEGORY.TCHS );
-        } else if (result.matches("(?i).*(TCO|(top\\s*coder\\s*open)).*")) {
+        } else if (result.matches("(?i).*(TCO|(top\\s*coder\\s*open)).*") && ! result.contains("SRM") ) {
             result = text.get( CATEGORY.TCO );
         } else if (result.contains("TCCC")) {
             result = text.get( CATEGORY.TCCC );

--- a/src/test/java/greed/template/ContestCategoryRendererTest.java
+++ b/src/test/java/greed/template/ContestCategoryRendererTest.java
@@ -49,6 +49,7 @@ public class ContestCategoryRendererTest {
         cases.put("TCO 13 Qual 2", "TCO");
         cases.put("TCHS 123", "TCHS");
         cases.put("TCCC 2004 Round 1", "TCCC");
+        cases.put("TCO19 SRM 755", "SRM");
 
         for(Map.Entry<String, String> entry : cases.entrySet()) {
             Map<String, Object> model = createModel("Contest", entry.getKey(), 1);


### PR DESCRIPTION
The category renderer has been broken for a while now because Topcoder have started to use names like "TCO19 SRM 755" for their SRMs. So category renders as TCO instead of SRM or SRM XXX-YYY. This fixes that